### PR TITLE
Fix memory leak / performance degradation

### DIFF
--- a/src/widgets/MainPanel.js
+++ b/src/widgets/MainPanel.js
@@ -507,6 +507,7 @@ class MainPanel extends BaseWidget {
     const content = formatRows(
       this.rows, columns, this.colSpacing, this.pageWidth-1).map(highlight).join('\n');
     const list = blessed.element({ tags: true, content });
+    this.children.forEach(child => this.remove(child));
     this.append(list);
     this.screen.render();
     if (notify) {


### PR DESCRIPTION
On every re-render, ```update()``` method was calling ```this.append(list)```, that kept adding the rows widgets to the **MainPanel** over and over again, without ever cleaning up. 

You could see the performance degradation when moving back and forth through the log list – the more you moved, the slower it became, to the point of unusability.

Cleaning up the list of children of **MainPanel** before re-adding the updated rows fixed the issue.